### PR TITLE
FEM-1846 Prevent a case where more than one timer is working in paralle

### DIFF
--- a/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/KavaAnalyticsPlugin.java
+++ b/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/KavaAnalyticsPlugin.java
@@ -394,6 +394,11 @@ public class KavaAnalyticsPlugin extends PKPlugin {
     }
 
     private void startAnalyticsTimer() {
+        if (viewEventTimer != null) {
+            viewEventTimeCounter = 0;
+            viewEventTimer.cancel();
+            viewEventTimer = null;
+        }
         viewEventTimer = new Timer();
         viewEventTimer.scheduleAtFixedRate(new TimerTask() {
             @Override


### PR DESCRIPTION
this can cause the counter to count up to 10 sec not in the correct time since it will + 1000 for each timer every sec

root cause was that the onApplicationPaused is called at start time and start the timer and also on LODED_METADATA the timer is started again with new timer instance