### PR TITLE
FEM-2157 Reset counters on lock duration > 30 sec,  playbackType is live until first play comes

### DIFF
--- a/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/DataHandler.java
+++ b/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/DataHandler.java
@@ -64,6 +64,7 @@ class DataHandler {
     private AverageBitrateCounter averageBitrateCounter;
 
     private boolean onApplicationPaused = false;
+    private boolean isFirstPlay;
 
     DataHandler(Context context, Player player) {
         this.context = context;
@@ -301,6 +302,7 @@ class DataHandler {
      */
     void handleFirstPlay() {
         joinTimeStartTimestamp = System.currentTimeMillis();
+        isFirstPlay = true;
     }
 
     /**
@@ -415,6 +417,11 @@ class DataHandler {
         }
         if (event == KavaEvents.IMPRESSION) {
             //For Impression event assume that playbackType is live.
+            return false;
+        }
+
+        if(isFirstPlay) {
+            isFirstPlay = false;
             return false;
         }
 

--- a/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/KavaAnalyticsPlugin.java
+++ b/kavaplugin/src/main/java/com/kaltura/playkit/plugins/kava/KavaAnalyticsPlugin.java
@@ -67,6 +67,7 @@ public class KavaAnalyticsPlugin extends PKPlugin {
 
     private ViewTimer viewTimer;
     private ViewTimer.ViewEventTrigger viewEventTrigger = initViewTrigger();
+    private long applicationBackgroundTimeStamp;
 
 
     public static final Factory factory = new Factory() {
@@ -117,7 +118,7 @@ public class KavaAnalyticsPlugin extends PKPlugin {
     @Override
     protected void onApplicationPaused() {
         log.d("onApplicationPaused");
-
+        applicationBackgroundTimeStamp = System.currentTimeMillis();
         if (dataHandler != null) {
             dataHandler.onApplicationPaused();
         }
@@ -130,7 +131,10 @@ public class KavaAnalyticsPlugin extends PKPlugin {
     @Override
     protected void onApplicationResumed() {
         log.d("onApplicationResumed");
-
+        long currentTimeInSeconds = System.currentTimeMillis() - applicationBackgroundTimeStamp / Consts.MILLISECONDS_MULTIPLIER;
+        if (currentTimeInSeconds >= 30) {
+            dataHandler.handleViewEventSessionClosed();
+        }
         if (dataHandler != null) {
             dataHandler.setOnApplicationResumed();
         }


### PR DESCRIPTION
When locking the phone for more than 30 seconds, the counters are no reset - FIX

When using autoplay in LIVE video, the first event is fired with playbackType=dvr - FIX